### PR TITLE
Move orig key and crt files instead of deleting

### DIFF
--- a/scripts/reload.acme.sh
+++ b/scripts/reload.acme.sh
@@ -2,4 +2,5 @@
 
 mkdir -p /config/ssl
 cat /tmp/server.key /tmp/full.cer > /config/ssl/server.pem
-rm /tmp/server.key /tmp/full.cer
+mv /tmp/server.key /config/ssl/server.key
+mv /tmp/full.cer /config/ssl/server.crt

--- a/scripts/renew.acme.sh
+++ b/scripts/renew.acme.sh
@@ -65,24 +65,24 @@ accesslog.filename = "$ACMEHOME/lighttpd.log"
 EOF
 ) >$ACMEHOME/lighttpd.conf
 
-log "Stopping gui service."
+log "Stopping GUI service."
 if [ -e "/var/run/lighttpd.pid" ]
 then
     kill_and_wait $(cat /var/run/lighttpd.pid)
 fi
 
-log "Starting temporary acme challenge service."
+log "Starting temporary ACME challenge service."
 /usr/sbin/lighttpd -f $ACMEHOME/lighttpd.conf
 
 /sbin/iptables -I INPUT 1 -p tcp -m comment --comment TEMP_LETSENCRYPT -m tcp --dport 80 -j ACCEPT
 $ACMEHOME/acme.sh --issue $DOMAINARG -w $ACMEHOME/webroot --home $ACMEHOME --local-address $WANIP --keypath /tmp/server.key --fullchainpath /tmp/full.cer --reloadcmd /config/scripts/reload.acme.sh
 /sbin/iptables -D INPUT 1
 
-log "Stopping temporary acme challenge service."
+log "Stopping temporary ACME challenge service."
 if [ -e "$ACMEHOME/lighttpd.pid" ]
 then
     kill_and_wait $(cat $ACMEHOME/lighttpd.pid)
 fi
 
-log "Starting gui service."
+log "Starting GUI service."
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
Instead of deleting them, move the newly-created `.key` and `.crt` files to the EdgeRouter's `/config/ssl` directory so they are available for use on additional network devices that share the same FQDN as the EdgeRouter but which are port-forwarded by the EdgeRouter to a different port.