### PR TITLE
Complete chain validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ chmod 755 /config/.acme.sh/acme.sh /config/scripts/renew.acme.sh
 
     ```
     set service gui cert-file /config/ssl/server.pem
+    set service-gui ca-file /config/ssl/ca.pem
     ```
 
 3. Configure task scheduler to renew certificate automatically.
@@ -68,6 +69,7 @@ chmod 755 /config/.acme.sh/acme.sh /config/scripts/renew.acme.sh
 
 ## Changelog
 
+    20171028 - Add ca.pem for complete certificate chain
     20171013 - Remove reload.acme.sh
     20170530 - Check wan ip
     20170417 - Stop gui service during challenge

--- a/scripts/renew.acme.sh
+++ b/scripts/renew.acme.sh
@@ -77,7 +77,7 @@ log "Starting temporary ACME challenge service."
 /sbin/iptables -I INPUT 1 -p tcp -m comment --comment TEMP_LETSENCRYPT -m tcp --dport 80 -j ACCEPT
 mkdir -p /config/ssl
 $ACMEHOME/acme.sh --issue $DOMAINARG -w $ACMEHOME/webroot --home $ACMEHOME \
---reloadcmd "cat $ACMEHOME/${DOMAIN[0]}/fullchain.cer $ACMEHOME/${DOMAIN[0]}/${DOMAIN[0]}.key > /config/ssl/server.pem"
+--reloadcmd "cat $ACMEHOME/${DOMAIN[0]}/${DOMAIN[0]}.cer $ACMEHOME/${DOMAIN[0]}/${DOMAIN[0]}.key > /config/ssl/server.pem; cat $ACMEHOME/${DOMAIN[0]}/ca.cer > /config/ssl/ca.pem"
 /sbin/iptables -D INPUT 1
 
 log "Stopping temporary ACME challenge service."


### PR DESCRIPTION
Add ca.pem to have a full chain validation for lighttpd.

Lighttpd needs to have the certificate authority in a separate file, it doesn't take the full chain certificate in only one file.
