### PR TITLE
Suggest to turn off port forwarding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ chmod 755 /config/.acme.sh/acme.sh /config/scripts/renew.acme.sh
   * 192.168.1.1 - LAN IP of Router
   * eth0 - WAN device
 * Configure DNS record for subdomain.example.com to your public WAN IP.
+* Temporarily disable port forwarding for port 80 if you have configured it before.
 * Connect via ssh to your EdgeRouter and enter configuration mode.
 
 1. Setup static host mapping for FQDN to the LAN IP.


### PR DESCRIPTION
This bit me today 😆, if you have port forwarding enabled for port 80 before running this script, the lighttpd process won't be able to receive the call from Let's Encrypt. 

I'm wondering if a better solution would be to temporarily disable port forwarding in the script, and then re-enable it at the end if it was previously enabled - otherwise, the scheduled job won't work.