### PR TITLE
Determine $WANIP when multiple IPs are set

### DIFF
--- a/scripts/renew.acme.sh
+++ b/scripts/renew.acme.sh
@@ -44,7 +44,7 @@ for val in "${DOMAIN[@]}"; do
 done
 
 ACMEHOME=/config/.acme.sh
-WANIP=$(ip addr show $WAN | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+WANIP=$(ip addr show $WAN | grep "inet\b" | awk '{print $2}' | head -n 1 | cut -d/ -f1)
 
 if [ -z "$WANIP" ]; then
     log "Unable to determine WAN IP."


### PR DESCRIPTION
This commit modifies the logic to of the `renew.acme.sh` script to pull the first WAN IP address when there are multiple addresses on the specified $WAN interface.

As an example, with the current implementation:

```
brooks@ubnt# ip addr show switch0.4094
14: switch0.4094@switch0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether f0:9f:c2:6f:23:9f brd ff:ff:ff:ff:ff:ff
    inet 8.8.8.8/32 scope global switch0.4094
       valid_lft forever preferred_lft forever
    inet 10.70.254.11/32 scope global switch0.4094
       valid_lft forever preferred_lft forever
    inet6 fe80::f29f:c2ff:fe6f:239f/64 scope link
       valid_lft forever preferred_lft forever
```

Would result in a `$WANIP` of:

```
brooks@ubnt# ip addr show switch0.4094 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1
8.8.8.8
10.70.254.11
```

Causing a `Verify error: connection refused`.

This commit, rather unintelligently just grabs the first address:

```
brooks@ubnt# ip addr show switch0.4094 | grep "inet\b" | awk '{print $2}' | head -n 1 | cut -d/ -f1
8.8.8.8
```