### PR TITLE
 Change step order in README to correctly init certs and commit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ curl https://raw.githubusercontent.com/j-c-m/ubnt-letsencrypt/master/install.sh 
     ```
     commit
     save
+    exit
     ```
 
 5. Initialize your certificate.
@@ -62,7 +63,7 @@ curl https://raw.githubusercontent.com/j-c-m/ubnt-letsencrypt/master/install.sh 
     ```
 
     If you included multiple names in step 3, you'll need to include any additional names here as well.
-    
+
 6. Accesss your router by going to <https://subdomain.example.com>
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -48,25 +48,26 @@ curl https://raw.githubusercontent.com/j-c-m/ubnt-letsencrypt/master/install.sh 
     set system task-scheduler task renew.acme executable arguments '-d subdomain.example.com -d subdomain2.example.com'
     ```
 
-4. Initialize your certificate.
-
-    ```
-    sudo /config/scripts/renew.acme.sh -d subdomain.example.com
-    ```
-
-    If you included multiple names in step 4, you'll need to include any additional names here as well.
-
-5. Commit and save your configuration.
+4. Commit and save your configuration.
 
     ```
     commit
     save
     ```
 
+5. Initialize your certificate.
+
+    ```
+    sudo /config/scripts/renew.acme.sh -d subdomain.example.com
+    ```
+
+    If you included multiple names in step 3, you'll need to include any additional names here as well.
+    
 6. Accesss your router by going to <https://subdomain.example.com>
 
 ## Changelog
 
+    20190302 - Changed step order in README to correctly init 
     20180609 - Install script
     20180605 - IPv6 support
     20180213 - Deprecate -i <wandev> option


### PR DESCRIPTION
I followed your original steps in your README.  However, upon step 5 (initialize the certificate), the task fails because we are still in configuration "edit" mode.  I subsequently, commit-ed, saved, and exited configuration mode, then performed the initialization.  This pull request has the correct ordering of commands for initial setup documented in the README.