### PR TITLE
Adding basic systemctl support for edgerouter 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to generate a valid SSL certificate for the EdgeRouter.
 
 * Connect via ssh to your EdgeRouter and execute the following command.
 ```
-curl https://raw.githubusercontent.com/j-c-m/ubnt-letsencrypt/master/install.sh | sudo bash
+curl https://raw.githubusercontent.com/ozphb/ubnt-letsencrypt/master/install.sh | sudo bash
 ```
 
 ## Configuration

--- a/install.sh
+++ b/install.sh
@@ -2,5 +2,5 @@
 
 mkdir -p /config/.acme.sh /config/scripts
 curl -o /config/.acme.sh/acme.sh https://raw.githubusercontent.com/Neilpang/acme.sh/master/acme.sh
-curl -o /config/scripts/renew.acme.sh https://raw.githubusercontent.com/j-c-m/ubnt-letsencrypt/master/renew.acme.sh
+curl -o /config/scripts/renew.acme.sh https://raw.githubusercontent.com/ozphb/ubnt-letsencrypt/master/renew.acme.sh
 chmod 755 /config/.acme.sh/acme.sh /config/scripts/renew.acme.sh

--- a/renew.acme.sh
+++ b/renew.acme.sh
@@ -5,12 +5,13 @@ usage() {
 }
 
 kill_and_wait() {
+
     local pid=$1
     [ -z $pid ] && return
 
     kill -s INT $pid 2> /dev/null
     while kill -s 0 $pid 2> /dev/null; do
-        sleep 1
+    sleep 1
     done
 }
 
@@ -61,6 +62,9 @@ EOF
 ) >$ACMEHOME/lighttpd.conf
 
 log "Stopping GUI service."
+systemctl stop lighttpd.service
+#wait 10
+
 if [ -e "/var/run/lighttpd.pid" ]
 then
     kill_and_wait $(cat /var/run/lighttpd.pid)
@@ -82,10 +86,12 @@ $ACMEHOME/acme.sh --issue $DOMAINARG -w $ACMEHOME/webroot --home $ACMEHOME \
 /sbin/iptables -t nat -D PREROUTING 1
 
 log "Stopping temporary ACME challenge service."
+
 if [ -e "$ACMEHOME/lighttpd.pid" ]
 then
     kill_and_wait $(cat $ACMEHOME/lighttpd.pid)
 fi
 
 log "Starting GUI service."
-/usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
+#/usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
+systemctl start lighttpd.service


### PR DESCRIPTION
Thanks for your excellent work.

Your script fails to reliably start and stop Lighttpd on version 2.x.

Because 2.x uses systemd I think the script should use systemctl [start/stop] lighttpd.service.

I have made some very (very) basic edits which seem to work and allow the script to run properly on the 2.x firmware.   I have no doubt they need improvement, but this may provide a small starter...

